### PR TITLE
Add TrainArea class and bump detection

### DIFF
--- a/Assets/OfTrains/TrainScene.tscn
+++ b/Assets/OfTrains/TrainScene.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=5 format=3 uid="uid://431vf1hdo80s"]
+[gd_scene load_steps=6 format=3 uid="uid://431vf1hdo80s"]
 
 [ext_resource type="Script" uid="uid://nx7yv1q5aqql" path="res://Scripts/Trains/Train.cs" id="1_7umcr"]
 [ext_resource type="Texture2D" uid="uid://1k2wair1yols" path="res://Assets/OfTrains/toy-train.png" id="1_yjeji"]
 [ext_resource type="AudioStream" uid="uid://bi15syf8bq7se" path="res://Assets/OfTrains/train-whistle-306031.mp3" id="3_ebsfl"]
+[ext_resource type="Script" uid="uid://d9ljwe27xn2r" path="res://Scripts/Trains/TrainArea.cs" id="1_2zpgm"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ebsfl"]
 size = Vector2(52, 46)
@@ -22,6 +23,7 @@ autoplay = true
 [node name="ChufChuf" type="AudioStreamPlayer2D" parent="."]
 
 [node name="Area" type="Area2D" parent="."]
+script = ExtResource("1_2zpgm")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area"]
 shape = SubResource("RectangleShape2D_ebsfl")

--- a/Scripts/Match/Match.cs
+++ b/Scripts/Match/Match.cs
@@ -1,0 +1,16 @@
+using Godot;
+
+public partial class Match : Node
+{
+    [Export] Stage stage;
+
+    public override void _Ready()
+    {
+        stage.Bump += OnBump;
+    }
+
+    void OnBump()
+    {
+        GD.Print("Match lost");
+    }
+}

--- a/Scripts/Match/Match.cs.uid
+++ b/Scripts/Match/Match.cs.uid
@@ -1,0 +1,1 @@
+uid://m5kqj42h4s2f

--- a/Scripts/Paths/EndPathArea.cs
+++ b/Scripts/Paths/EndPathArea.cs
@@ -12,6 +12,9 @@ public partial class EndPathArea : Area2D
 
     void OnTrainEnter(Area2D area)
     {
+        if (area is not TrainArea)
+            return;
+
         GD.Print("Path reached the end!");
         TrainArrived?.Invoke();
     }

--- a/Scripts/Stage/Stage.cs
+++ b/Scripts/Stage/Stage.cs
@@ -14,6 +14,7 @@ public partial class Stage : Node
     bool spawningLabel = false;
 
     public event Action<string> KeyRegistered;
+    public event Action Bump;
 
     public override void _Ready()
     {
@@ -40,6 +41,9 @@ public partial class Stage : Node
         var action_key = $"train_{n}";
         KeyRegistered?.Invoke(action_key);
         paths.Add((path, action_key));
+
+        var area = train.GetNode<TrainArea>("Area");
+        area.BumpedTrain += () => Bump?.Invoke();
 
         labelQueue.Enqueue(action_key);
         TrySpawnLabel();

--- a/Scripts/Trains/TrainArea.cs
+++ b/Scripts/Trains/TrainArea.cs
@@ -1,0 +1,18 @@
+using System;
+using Godot;
+
+public partial class TrainArea : Area2D
+{
+    public event Action BumpedTrain;
+
+    public override void _Ready()
+    {
+        AreaEntered += OnAreaEntered;
+    }
+
+    void OnAreaEntered(Area2D area)
+    {
+        if (area is TrainArea)
+            BumpedTrain?.Invoke();
+    }
+}

--- a/Scripts/Trains/TrainArea.cs.uid
+++ b/Scripts/Trains/TrainArea.cs.uid
@@ -1,0 +1,1 @@
+uid://d9ljwe27xn2r


### PR DESCRIPTION
## Summary
- introduce a TrainArea script inheriting from Area2D
- attach TrainArea to Train scene's Area2D and adjust scene resource setup
- ensure EndPathArea only reacts to TrainArea
- fire a BumpedTrain event when one train's area enters another
- have Stage listen to each train's BumpedTrain and emit a Bump event
- add Match class that responds to Stage's Bump event

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e68da268832ca97c6a50cecf6554