### PR TITLE
Add main menu buttons

### DIFF
--- a/Scenes/MainMenu.tscn
+++ b/Scenes/MainMenu.tscn
@@ -34,3 +34,7 @@ text = "Settings"
 [node name="QuitButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 text = "Quit"
+
+[connection signal="button_up" from="VBoxContainer/PlayButton" to="." method="OnPlayPressed"]
+[connection signal="button_up" from="VBoxContainer/SettingsButton" to="." method="OnSettingsPressed"]
+[connection signal="button_up" from="VBoxContainer/QuitButton" to="." method="OnQuitPressed"]

--- a/Scenes/MainMenu.tscn
+++ b/Scenes/MainMenu.tscn
@@ -1,16 +1,18 @@
-[gd_scene format=3 uid="uid://ctm1pvtmwc7es"]
+[gd_scene load_steps=2 format=3 uid="uid://ctm1pvtmwc7es"]
 
-[ext_resource type="Script" path="res://Scripts/MainMenu/MainMenu.cs" id="1_q7e13"]
+[ext_resource type="Script" uid="uid://bbcgdqonsfuaw" path="res://Scripts/MainMenu/MainMenu.cs" id="1_q7e13"]
 
 [node name="MainMenu" type="Control"]
-script = ExtResource("1_q7e13")
+layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_q7e13")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -22,14 +24,13 @@ offset_bottom = 60.0
 alignment = 1
 
 [node name="PlayButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
 text = "Play"
 
 [node name="SettingsButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
 text = "Settings"
 
 [node name="QuitButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
 text = "Quit"
-
-[connection signal="pressed" from="PlayButton" to="." method="OnPlayPressed"]
-[connection signal="pressed" from="SettingsButton" to="." method="OnSettingsPressed"]
-[connection signal="pressed" from="QuitButton" to="." method="OnQuitPressed"]

--- a/Scenes/MainMenu.tscn
+++ b/Scenes/MainMenu.tscn
@@ -1,3 +1,35 @@
 [gd_scene format=3 uid="uid://ctm1pvtmwc7es"]
 
-[node name="MainMenu" type="Node"]
+[ext_resource type="Script" path="res://Scripts/MainMenu/MainMenu.cs" id="1_q7e13"]
+
+[node name="MainMenu" type="Control"]
+script = ExtResource("1_q7e13")
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -60.0
+offset_top = -60.0
+offset_right = 60.0
+offset_bottom = 60.0
+alignment = 1
+
+[node name="PlayButton" type="Button" parent="VBoxContainer"]
+text = "Play"
+
+[node name="SettingsButton" type="Button" parent="VBoxContainer"]
+text = "Settings"
+
+[node name="QuitButton" type="Button" parent="VBoxContainer"]
+text = "Quit"
+
+[connection signal="pressed" from="PlayButton" to="." method="OnPlayPressed"]
+[connection signal="pressed" from="SettingsButton" to="." method="OnSettingsPressed"]
+[connection signal="pressed" from="QuitButton" to="." method="OnQuitPressed"]

--- a/Scripts/MainMenu/MainMenu.cs
+++ b/Scripts/MainMenu/MainMenu.cs
@@ -1,0 +1,19 @@
+using Godot;
+
+public partial class MainMenu : Control
+{
+    public void OnPlayPressed()
+    {
+        GetTree().ChangeSceneToFile("res://Scenes/Main.tscn");
+    }
+
+    public void OnSettingsPressed()
+    {
+        GD.Print("Settings pressed");
+    }
+
+    public void OnQuitPressed()
+    {
+        GetTree().Quit();
+    }
+}

--- a/Scripts/MainMenu/MainMenu.cs.uid
+++ b/Scripts/MainMenu/MainMenu.cs.uid
@@ -1,0 +1,1 @@
+uid://bbcgdqonsfuaw

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Trains"
-run/main_scene="uid://4kraj3jvxem4"
+run/main_scene="uid://ctm1pvtmwc7es"
 config/features=PackedStringArray("4.4", "C#", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
## Summary
- Populate MainMenu scene with Play, Settings, and Quit buttons
- Add MainMenu script to handle basic button actions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a10031cd94832cb952dcae75abcd6e