### PR TITLE
Allow sprint via train click

### DIFF
--- a/Scripts/Stage/Stage.cs
+++ b/Scripts/Stage/Stage.cs
@@ -49,6 +49,18 @@ public partial class Stage : Node
         paths.Add((path, action_key));
 
         var area = train.GetNode<TrainArea>("Area");
+        area.InputPickable = true;
+        area.InputEvent += (viewport, @event, shapeIdx) =>
+        {
+            if (@event is InputEventMouseButton mouseEvent &&
+                mouseEvent.ButtonIndex == MouseButton.Left)
+            {
+                if (mouseEvent.Pressed)
+                    Input.ActionPress(action_key);
+                else
+                    Input.ActionRelease(action_key);
+            }
+        };
         area.BumpedTrain += () => Bump?.Invoke();
         path.End.TrainArrived += OnTrainArrived;
 


### PR DESCRIPTION
## Summary
- Allow trains to start sprinting when their train is clicked
- Hook train area mouse events to press/release the sprint action

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a45d610ed8832cb9fea405406df6bf